### PR TITLE
Fix the return URL by using s3.amazonaws.com.

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ S3Store.prototype.save = function(image) {
 
     var targetDir = self.getTargetDir();
     var targetFilename = self.getTargetName(image, targetDir);
-    var awsPath = options.assetHost ? options.assetHost : 'https://' + options.bucket + '.amazonaws.com/';
+    var awsPath = options.assetHost ? options.assetHost : 'https://' + options.bucket + '.s3.amazonaws.com/';
 
     return readFile(image.path)
     .then(function(buffer) {


### PR DESCRIPTION
Just tried using this library and it wasn't working.

Using the 's3' subdomain fixed it.
