### PR TITLE
license information

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Hoang Pham Huu <phamhuuhoang@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ You can use assetHost config to specify S3 bucket full-url in virtual host style
 
 Restart app then test upload new image in blog post. Image will be store at newly S3 bucket.
 
-## License
+## Copyright & License
 
-Read LICENSE
+Copyright (c) 2015  Hoang Pham Huu <phamhuuhoang@gmail.com>
+
+Released under the [MIT license](https://github.com/muzix/ghost-s3/blob/master/LICENSE).
+


### PR DESCRIPTION
Hello!

Thanks for this very nice extension for Ghost. While I was playing with it, I saw the README referenced a LICENSE file that doesn't exist in the main repository. Since `package.json` mentions it's licensed under MIT, I took the liberty to add the MIT license with the proper copyright holder information, and update the reference in the README.

Hope this helps! Cheers!
