### PR TITLE
new option 'pathPrefix' for sharing S3 buckets and CloudFront settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,25 @@ You can use assetHost config to specify S3 bucket full-url in virtual host style
 
 Restart app then test upload new image in blog post. Image will be store at newly S3 bucket.
 
+**Note 2**
+Uploads will be saved in the specified S3 bucket using keys (paths) in the form of
+`/year/month/imageName-timeStamp.ext`, where:
+
+* year      - 4 digits of the current year;
+* month     - 3 letter english abbreviation of the current month;
+* imageName - the original file name, with special characters converted to "_";
+* timeStamp - timestamp in milliseconds;
+* ext       - the original file's extension (e.g. "png");
+
+If, for whatever reason, you need to prefix that path with something, you can use
+the `pathPrefix` config option, like so:
+
+    pathPrefix: "some/path"
+
+This will save files in `pathPrefix/year/month/...`, so you can neatly store ghost
+files and either share the S3 bucket with other apps or use CloudFront prefix rules
+as you see fit.
+
 ## License
 
 Read LICENSE

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ S3Store.prototype.save = function(image) {
     var self = this;
     if (!options) return when.reject('ghost-s3 is not configured');
 
-    var targetDir = self.getTargetDir();
+    var targetDir = self.getTargetDir(options);
     var targetFilename = self.getTargetName(image, targetDir);
     var awsPath = options.assetHost ? options.assetHost : 'https://' + options.bucket + '.s3.amazonaws.com/';
 
@@ -63,13 +63,21 @@ S3Store.prototype.serve = function() {
     };
 };
 
-S3Store.prototype.getTargetDir = function() {
+S3Store.prototype.getTargetDir = function(options) {
     var MONTHS = [
         'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
         'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
     ];
     var now = new Date();
-    return now.getFullYear() + '/' + MONTHS[now.getMonth()] + '/';
+    var prefix = options.pathPrefix ? options.pathPrefix : '';
+
+    // append a '/' to prefix if necessary
+    var pos = prefix.length - 1;
+    if (prefix.length && prefix.indexOf('/', pos) != pos) {
+        prefix = prefix + '/';
+    }
+
+    return prefix + now.getFullYear() + '/' + MONTHS[now.getMonth()] + '/';
 };
 
 S3Store.prototype.getTargetName = function(image, targetDir) {


### PR DESCRIPTION
Hello! Me again :)

This PR introduces the `pathPrefix` option. Without this, the plugin creates several "folders" in the root of the bucket, like "2014", "2015", etc. While I don't really share ghost's bucket with the rest of the app, I do share the CloudFront cdn. This means that I want some prefixes to be forwarded by cloudfront to bucket A and ghost's prefixes to bucket B. If I make a rule for paths starting with "2015" it works, but I don't want to have to worry about this when the year changes :)

With this patch, ghost can coexist with the rest of my website, both sharing the CDN. It also looks much nicer and tidier when browsing the bucket!

This patch is actually very punctual and does not break any compatibilities with the current settings. The prefix, of course, defaults to "".

Anyway, I hope it helps!
