### PR TITLE
Allow use of proxy when storing uploads to S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Add `storage` block to file `config.js` in each environment as below:
             secretAccessKey: 'Put_your_secret_key_here',
             bucket: 'Put_your_bucket_name',
             region: 'Put_your_bucket_region',
-            assetHost: 'Put_your_cdn_url*'
+            assetHost: 'Put_your_cdn_url*',
+            proxyUrl: 'Put_your_proxy_url'
         }
     },
 

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var when = require('when');
 var readFile = nodefn.lift(fs.readFile);
 var unlink = nodefn.lift(fs.unlink);
 var AWS = require('aws-sdk');
+var proxy = require('proxy-agent');
 var options = {};
 
 function S3Store(config) {
@@ -24,6 +25,11 @@ S3Store.prototype.save = function(image) {
 
     return readFile(image.path)
     .then(function(buffer) {
+        if (options.proxyUrl) {
+          AWS.config.update({
+            httpOptions: { agent: proxy(options.proxyUrl) }
+          });
+        }
         var s3 = new AWS.S3({
           accessKeyId: options.accessKeyId,
           secretAccessKey: options.secretAccessKey,

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "homepage": "https://github.com/muzix/ghost-s3",
   "dependencies": {
     "aws-sdk": "^2.1.6",
-    "when": "^3.6.4"
+    "when": "^3.6.4",
+    "proxy-agent": "2.0.0"
   }
 }


### PR DESCRIPTION
It is common practice to isolate servers in a private network for security reasons.  When doing so, it is necessary to communicate with the public internet through a proxy.  This pull request allows a proxy url to be set so that communication with S3 can occur through the AWS SDK.  This implementation uses the recommended way to use a proxy from the AWS documentation (http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html)
![screen shot 2015-08-10 at 9 29 08 pm](https://cloud.githubusercontent.com/assets/4186661/9188150/e325429c-3fa6-11e5-957c-a73f0462d5f8.png)
