### PR TITLE
Set ACL on S3 uploads to 'public-read'

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ S3Store.prototype.save = function(image) {
         });
 
         return nodefn.call(s3.putObject.bind(s3), {
+            ACL: 'public-read',
             Bucket: options.bucket,
             Key: targetFilename,
             Body: buffer,


### PR DESCRIPTION
Without setting this property, uploads will inherit the bucket's default acl, which, depending on your configuration, may not be public. If the bucket is not set up as a static website or completely public, after saving (which will succeed), the ghost uploader will hang because the uploaded file will not be available to view (even though it was successfully uploaded).

However, since this storage module is specifically for making resources public, this sets the 'public-read' acl for uploaded resources so that they'll be visible regardless of the permissions on the bucket they're uploaded to.

tested on a bucket with no default global read permissions.
